### PR TITLE
Add clickable project image and GitHub icon styling

### DIFF
--- a/src/components/Project.css
+++ b/src/components/Project.css
@@ -43,21 +43,35 @@
   margin-top: 20px;
 }
 
+.icon {
+  color: #98FF4C;
+  font-size: 24px; 
+  margin: 3px 0 0 10px; 
+}
+
+.icon:hover {
+  color: #DEF1CD;
+}
+
 .descrip {
   color: #DEF1CD;
   display: flex;
   justify-content: center;
-  margin-top: 25px;
+  margin-top: 20px;
   font-size: 1.4rem;
 }
 
 .technologies {
   color: #DEF1CD;
-  margin: 25px 0 20px 0;
+  margin-top: 20px;
   display: flex;
   flex-direction: column;
   align-items: center;
   font-size: 1.4rem;
+}
+
+span {
+  margin-top: 20px;
 }
 
 .strong-tech {

--- a/src/components/Project.jsx
+++ b/src/components/Project.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FaGithub } from 'react-icons/fa';
 import * as projects from '../assets';
 import './Project.css';
 
@@ -9,13 +10,14 @@ function Project({ project }) {
 
   return (
     <div className="project-item">
+      <a href={link} target='_blank' rel='noopener noreferrer'>
       <img src={projects[image]} alt={name} className="project-image" />
+      </a>
       <div className="project-info">
         <h1>
           <a href={link} target='_blank' rel='noopener noreferrer' className='project-title'>{name}</a>{' '}
           <a href={repo} target='_blank' rel='noopener noreferrer' className='repo'>
-            GitHub 
-            {/* <i className="fab fa-github"></i> */}
+            GitHub <FaGithub className='icon' />
           </a>
         </h1>
         <p className='descrip'>{description}</p>


### PR DESCRIPTION
- In the Project component, integrated functionality to make the project image clickable, linking to the project's URL.
- Styled the GitHub icon for enhanced visual presentation and consistency across project listings.
- Made the color inverted on github icon :hover
 