### PR TITLE
Reduced media query heights

### DIFF
--- a/src/components/Project.css
+++ b/src/components/Project.css
@@ -79,7 +79,11 @@ span {
 }
 
 @media (max-width: 700px) {
+  .project-item {
+    height: 650px;
+  }
+  
   .project-image {
-    height: 400px;
+    height: 300px;
   }
 }


### PR DESCRIPTION
- Height for project-container reduced from 850px on desktop view to 650px 
- Height reduced for project-image; 400 to 300px