### PR TITLE
docs: replace NBA Standings with Night Owlz, fix stale links and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,23 @@
 ![Screenshot of the Portfolio Project Page](src/assets/projects/project_page.png)
 ![Screenshot of the Portfolio Contact Page](src/assets/projects/contact_page.png)
 
-## Description 
-This is a portfolio I created with react. Using headers and footers combined with a navbar I was able to make a portfolio that is easy for the user to navigate through
+## Live
 
-## Table of Contents 📝
+[brandon-kellys-portfolio.netlify.app](https://brandon-kellys-portfolio.netlify.app)
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Test](#test)
-- [Contributing](#contributing)
+## Quick Start
 
-- [Questions](#questions-📝)
-
-## Installation 
-npm i
-
-## Usage
-To install this repo the user would have to install the packages with npm install and then run node on the index.js file.
-
-## Test 
-npm test
+```sh
+git clone https://github.com/bkness/react-portfolio.git
+cd react-portfolio
+npm install
+npm run dev
+```
 
 ## Contributing
-Fork the project and open a pull request with your new code
 
-## Deployed 
-The github repo can be viewed [here](https://github.com/bkness/React-Portfolio)
+Fork the project and open a pull request with your new code.
 
-The deployed profile can be viewed [here](https://jazzy-scone-ff682e.netlify.app/)
+## Contact
 
-## Questions
-If you have any questions you can email me at kbrandon863@gmail.com if you want to see more of my work, visit my GitHub at [bkness](https://github.com/bkness)
+Brandon Kelly — [GitHub](https://github.com/bkness) · kbrandon863@gmail.com

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -5,7 +5,7 @@ export const projects = [
       "A dev environment toolkit published on npm. Includes a security scanner that checks npm packages for typosquatting, tarball integrity, and publisher rotation — plus project scaffolding, README generation, and shell workflow commands. Built with Node.js and ESM.",
     technologies: "Node.js / npm / ESM / CLI",
     link: "https://www.npmjs.com/package/forged-cli",
-    repo: "https://github.com/RevenueWebs/forged-cli",
+    repo: "https://github.com/bkness/forged-cli",
     image: "readme_gen",
   },
   {
@@ -23,7 +23,7 @@ export const projects = [
       "Full-stack MERN application with GraphQL and Apollo for secure authentication. Features a gaming news feed powered by a News API, a blog system with GraphQL queries and mutations, and JWT-based user auth. Built collaboratively using Agile methodologies.",
     technologies: "MongoDB / GraphQL / Apollo / React / Node / JWT",
     link: "https://video-gaming-hub.onrender.com/",
-    repo: "https://github.com/bkness/Video-Gaming-Hub",
+    repo: "https://github.com/bkness/game-hub",
     image: "game",
   },
   {
@@ -32,25 +32,25 @@ export const projects = [
       "Full-stack application that lets users log in, search for, and save their favorite breweries. Includes commenting, favorites management, and interactive maps via Leaflet. Built with a team of four using Node.js, Express, MySQL, Handlebars, and Sequelize.",
     technologies: "Node / Express / MySQL / Handlebars / Sequelize / Leaflet",
     link: "https://brewery-search.onrender.com/",
-    repo: "https://github.com/bkness/Local-Breweries",
+    repo: "https://github.com/bkness/breweries",
     image: "localbreweries",
   },
   {
-    name: "MVC Tech Blog",
+    name: "Devlog",
     description:
       "Dynamic tech blog using the MVC architecture. Users can manage accounts, publish, update, and comment on posts. Implements bcrypt for password hashing and express-session for user session management, with Handlebars for dynamic rendering.",
     technologies: "Node / Express / MySQL / Handlebars / Sequelize / Bcrypt",
     link: "https://mvc-tech-blog-production-c752.up.railway.app/",
-    repo: "https://github.com/bkness/MVC-Tech-Blog",
+    repo: "https://github.com/bkness/devlog",
     image: "blog",
   },
   {
-    name: "Social Network API",
+    name: "Night Owlz",
     description:
-      "RESTful API backend for a social network built with MongoDB, Express, and Mongoose. Supports users sharing thoughts, reacting to friends' posts, and managing friend lists. Developed and tested with Insomnia.",
-    technologies: "MongoDB / Express / Mongoose / Node",
-    link: "https://www.youtube.com/watch?v=g3LsVPTANH0",
-    repo: "https://github.com/bkness/Social-Network-API",
+      "Full-stack React Native nightlife discovery app. Search any city for bars, clubs, and live music, save favorites, and explore venues with in-app maps. Features Apple MapKit JS with OpenStreetMap fallback, JWT auth, and a Node/Express backend deployed on Render.",
+    technologies: "React Native / Expo / Node / Express / MongoDB / JWT / Apple Maps",
+    link: "https://nightowlz.onrender.com",
+    repo: "https://github.com/bkness/nightowlz",
     image: "social",
   },
 ];

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -50,13 +50,13 @@ export default function Resume() {
       <h2 className="section-title">Technical Skills</h2> <br />
       <p className="skills">
         <strong className="skill-def">Languages:</strong> HTML5, CSS3,
-        JavaScript, React
+        JavaScript, Typescript
         <br />
         <strong className="skill-def">Frameworks & Libraries:</strong>{" "}
-        Bootstrap, Tailwind, jQuery, Redux, Handlebars.js, Node.js
+        Bootstrap, Tailwind, jQuery, Redux, Handlebars.js, Node.js, React Native, React, Expo
         <br />
         <strong className="skill-def">Tools & Platforms:</strong> Git, GitHub,
-        VS Code, Heroku, MongoDB, Netlify, Render, Firebase
+        VS Code, MongoDB, Netlify, Render, Firebase, Railway
         <br />
         <strong className="skill-def">Other:</strong> GraphQL, Responsive
         Design, RESTful APIs, Agile Methodologies
@@ -73,7 +73,7 @@ export default function Resume() {
         <strong className="project-description">Game Hub </strong>{" "}
         <span className="separator">|</span>
         <a
-          href="https://github.com/bkness/video-game-hub-project3"
+          href="https://github.com/bkness/game-hub"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -82,7 +82,7 @@ export default function Resume() {
         </a>{" "}
         <span className="separator">|</span>
         <a
-          href="https://video-game-hub-project3.onrender.com/"
+          href="https://video-gaming-hub.onrender.com/"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -109,7 +109,7 @@ export default function Resume() {
         <strong className="project-description">Local Brewery Finder</strong>{" "}
         <span className="separator">|</span>
         <a
-          href="https://github.com/bkness/LocalBreweries"
+          href="https://github.com/bkness/breweries"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -118,7 +118,7 @@ export default function Resume() {
         </a>{" "}
         <span className="separator">|</span>
         <a
-          href="https://radiant-fjord-87739-920e7bb79c22.herokuapp.com/"
+          href="https://brewery-search.onrender.com/"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -136,50 +136,33 @@ export default function Resume() {
         <strong className="project-description">
           Technologies | Languages:
         </strong>{" "}
-        Node.js, Express.js, RESTful API, Handlebars, SQL, NPM, Heroku, CSS,
+        Node.js, Express.js, RESTful API, Handlebars, SQL, NPM, Render, CSS,
         Google Fonts
       </div>{" "}
       <br />
-      <div className="project">
-        <strong className="project-description">
-          NBA Standings Application
-        </strong>{" "}
-        <span className="separator">|</span>
-        <a
-          href="https://github.com/bkness/jungle-map-api "
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {" "}
-          GitHub
-        </a>{" "}
-        <span className="separator">|</span>
-        <a
-          href="https://bkness.github.io/jungle-map-api/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {" "}
-          Live
-        </a>
-        <br /> <br />
-        <strong className="project-description">Responsibilities:</strong>{" "}
-        Responsive sports standings app using Tailwind, integrating two APIs for
-        real-time data and implementing client-side storage for persistent data{" "}
-        <br />
-        <strong className="project-description">Role:</strong> Integration of
-        Sports API, Modal design and functionality, CSS <br />
-        <strong className="project-description">
-          Technologies | Languages
-        </strong>{" "}
-        Server Side API, Local Storage, Tailwind CSS, HTML
-      </div>{" "}
-      <br />
+     <div className="project">
+    <strong className="project-description">Night Owlz</strong>{" "}
+    <span className="separator">|</span>
+    <a href="https://github.com/bkness/nightowlz" target="_blank" rel="noopener noreferrer"> GitHub</a>{" "}
+    <span className="separator">|</span>
+    <a href="https://nightowlz.onrender.com" target="_blank" rel="noopener noreferrer"> Live</a>
+    <br /> <br />
+    <strong className="project-description">Responsibilities:</strong>{" "}
+    Built a full-stack React Native nightlife discovery app — search any city for bars, clubs, and live music,
+    save favorites, and explore venues with in-app maps <br />
+    <strong className="project-description">Role:</strong> Sole developer — React Native client with Expo,
+  Node/Express REST API, Apple MapKit JS integration with OpenStreetMap fallback, JWT authentication and
+  bcrypt, deployed to Render
+    <br />
+    <strong className="project-description">Technologies | Languages:</strong>{" "}
+    React Native, Expo, Node.js, Express, MongoDB, Mongoose, JWT, Apple Maps, REST API, Render
+     <br /> <br />
+  </div>
       <div className="project">
         <strong className="project-description">Tech Blog</strong>{" "}
         <span className="separator">|</span>
         <a
-          href="https://github.com/bkness/MVC-Tech-Blog"
+          href="https://github.com/bkness/devlog"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -188,7 +171,7 @@ export default function Resume() {
         </a>{" "}
         <span className="separator">|</span>
         <a
-          href="https://mvc--tech-blog-715ec89956fb.herokuapp.com/"
+          href="https://mvc-tech-blog-production-c752.up.railway.app/"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
- Add Night Owlz project (React Native, Expo, Apple Maps, Render)
- Replace Social Network API with Night Owlz in portfolio grid
- Fix forged-cli repo URL (RevenueWebs → bkness)
- Fix Video Game Hub repo URL (Video-Gaming-Hub → game-hub)
- Fix MVC Tech Blog repo URL and name (MVC-Tech-Blog → devlog)
- Fix Local Breweries http → https and Heroku → Render in tech list
- Add TypeScript, React Native, Expo to skills; replace Heroku with Railway
- Fix README: correct deploy URL, usage command, remove stale links